### PR TITLE
Implement `std::error::Error` on `uinput_tokio::error::Error`

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,35 +16,30 @@ use std::time::Duration;
 use tokio;
 
 #[tokio::main]
-async fn main() {
-    let mut device = uinput_tokio::default()
-        .unwrap()
-        .name("test")
-        .unwrap()
-        .event(uinput_tokio::event::Keyboard::All)
-        .unwrap()
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut device = uinput_tokio::default()?
+        .name("test")?
+        .event(uinput_tokio::event::Keyboard::All)?
         .create()
-        .await
-        .unwrap();
+        .await?;
 
     thread::sleep(Duration::from_secs(1));
 
-    device.click(&keyboard::Key::H).await.unwrap();
-    device.click(&keyboard::Key::E).await.unwrap();
-    device.click(&keyboard::Key::L).await.unwrap();
-    device.click(&keyboard::Key::L).await.unwrap();
-    device.click(&keyboard::Key::O).await.unwrap();
-    device.click(&keyboard::Key::Space).await.unwrap();
-    device.click(&keyboard::Key::W).await.unwrap();
-    device.click(&keyboard::Key::O).await.unwrap();
-    device.click(&keyboard::Key::R).await.unwrap();
-    device.click(&keyboard::Key::L).await.unwrap();
-    device.click(&keyboard::Key::D).await.unwrap();
-    device.click(&keyboard::Key::Enter).await.unwrap();
+    device.click(&keyboard::Key::H).await?;
+    device.click(&keyboard::Key::E).await?;
+    device.click(&keyboard::Key::L).await?;
+    device.click(&keyboard::Key::L).await?;
+    device.click(&keyboard::Key::O).await?;
+    device.click(&keyboard::Key::Space).await?;
+    device.click(&keyboard::Key::W).await?;
+    device.click(&keyboard::Key::O).await?;
+    device.click(&keyboard::Key::R).await?;
+    device.click(&keyboard::Key::L).await?;
+    device.click(&keyboard::Key::D).await?;
+    device.click(&keyboard::Key::Enter).await?;
 
-    device.synchronize().await.unwrap();
+    device.synchronize().await
 }
-
 ```
 
 Example mouse
@@ -62,28 +57,23 @@ use uinput_tokio::event::relative::Relative::Position;
 use uinput_tokio::event::Event::{Controller, Relative};
 
 #[tokio::main]
-async fn main() {
-    let mut device = uinput_tokio::default()
-        .unwrap()
-        .name("test")
-        .unwrap()
-        .event(Controller(Mouse(Left)))
-        .unwrap() // It's necessary to enable any mouse button. Otherwise Relative events would not work.
-        .event(Relative(Position(X)))
-        .unwrap()
-        .event(Relative(Position(Y)))
-        .unwrap()
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut device = uinput_tokio::default()?
+        .name("test")?
+        .event(Controller(Mouse(Left)))?
+        // It's necessary to enable any mouse button. Otherwise Relative events would not work.
+        .event(Relative(Position(X)))?
+        .event(Relative(Position(Y)))?
         .create()
-        .await
-        .unwrap();
+        .await?;
 
     for _ in 1..10 {
         thread::sleep(Duration::from_secs(1));
 
-        device.send(X, 50).await.unwrap();
-        device.send(Y, 50).await.unwrap();
-        device.synchronize().await.unwrap();
+        device.send(X, 50).await?;
+        device.send(Y, 50).await?;
+        device.synchronize().await?;
     }
+    Ok(())
 }
-
 ```

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -7,31 +7,27 @@ use std::time::Duration;
 use tokio;
 
 #[tokio::main]
-async fn main() {
-    let mut device = uinput_tokio::default()
-        .unwrap()
-        .name("test")
-        .unwrap()
-        .event(uinput_tokio::event::Keyboard::All)
-        .unwrap()
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut device = uinput_tokio::default()?
+        .name("test")?
+        .event(uinput_tokio::event::Keyboard::All)?
         .create()
-        .await
-        .unwrap();
+        .await?;
 
     thread::sleep(Duration::from_secs(1));
 
-    device.click(&keyboard::Key::H).await.unwrap();
-    device.click(&keyboard::Key::E).await.unwrap();
-    device.click(&keyboard::Key::L).await.unwrap();
-    device.click(&keyboard::Key::L).await.unwrap();
-    device.click(&keyboard::Key::O).await.unwrap();
-    device.click(&keyboard::Key::Space).await.unwrap();
-    device.click(&keyboard::Key::W).await.unwrap();
-    device.click(&keyboard::Key::O).await.unwrap();
-    device.click(&keyboard::Key::R).await.unwrap();
-    device.click(&keyboard::Key::L).await.unwrap();
-    device.click(&keyboard::Key::D).await.unwrap();
-    device.click(&keyboard::Key::Enter).await.unwrap();
+    device.click(&keyboard::Key::H).await?;
+    device.click(&keyboard::Key::E).await?;
+    device.click(&keyboard::Key::L).await?;
+    device.click(&keyboard::Key::L).await?;
+    device.click(&keyboard::Key::O).await?;
+    device.click(&keyboard::Key::Space).await?;
+    device.click(&keyboard::Key::W).await?;
+    device.click(&keyboard::Key::O).await?;
+    device.click(&keyboard::Key::R).await?;
+    device.click(&keyboard::Key::L).await?;
+    device.click(&keyboard::Key::D).await?;
+    device.click(&keyboard::Key::Enter).await?;
 
-    device.synchronize().await.unwrap();
+    device.synchronize().await
 }

--- a/examples/mouse.rs
+++ b/examples/mouse.rs
@@ -10,26 +10,22 @@ use uinput_tokio::event::relative::Relative::Position;
 use uinput_tokio::event::Event::{Controller, Relative};
 
 #[tokio::main]
-async fn main() {
-    let mut device = uinput_tokio::default()
-        .unwrap()
-        .name("test")
-        .unwrap()
-        .event(Controller(Mouse(Left)))
-        .unwrap() // It's necessary to enable any mouse button. Otherwise Relative events would not work.
-        .event(Relative(Position(X)))
-        .unwrap()
-        .event(Relative(Position(Y)))
-        .unwrap()
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut device = uinput_tokio::default()?
+        .name("test")?
+        .event(Controller(Mouse(Left)))?
+        // It's necessary to enable any mouse button. Otherwise Relative events would not work.
+        .event(Relative(Position(X)))?
+        .event(Relative(Position(Y)))?
         .create()
-        .await
-        .unwrap();
+        .await?;
 
     for _ in 1..10 {
         thread::sleep(Duration::from_secs(1));
 
-        device.send(X, 50).await.unwrap();
-        device.send(Y, 50).await.unwrap();
-        device.synchronize().await.unwrap();
+        device.send(X, 50).await?;
+        device.send(Y, 50).await?;
+        device.synchronize().await?;
     }
+    Ok(())
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -50,6 +50,8 @@ impl fmt::Display for Error {
     }
 }
 
+impl std::error::Error for Error {}
+
 // impl error::Error for Error {
 //     fn description(&self) -> &str {
 //         return match self {

--- a/src/error.rs
+++ b/src/error.rs
@@ -49,6 +49,7 @@ impl fmt::Display for Error {
         let message = match self {
             Error::Nix(e) => e.to_string(),
             Error::Nul(e) => e.to_string(),
+            #[cfg(feature = "udev")]
             Error::Udev(e) => e.to_string(),
             Error::IoError(e) => e.to_string(),
             Error::NotFound => "Device not found.".to_string(),

--- a/src/error.rs
+++ b/src/error.rs
@@ -46,25 +46,15 @@ impl From<udev::Error> for Error {
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        f.write_str(&self.to_string())
+        let message = match self {
+            Error::Nix(e) => e.to_string(),
+            Error::Nul(e) => e.to_string(),
+            Error::Udev(e) => e.to_string(),
+            Error::IoError(e) => e.to_string(),
+            Error::NotFound => "Device not found.".to_string(),
+        };
+        f.write_str(&message)
     }
 }
 
 impl std::error::Error for Error {}
-
-// impl error::Error for Error {
-//     fn description(&self) -> &str {
-//         return match self {
-//             Error::Nix(ref err) => &err.to_string(),
-
-//             Error::Nul(ref err) => &err.to_string(),
-
-//             #[cfg(feature = "udev")]
-//             Error::Udev(ref err) => &err.to_string(),
-
-//             Error::IoError(ref err) => &err.to_string(),
-
-//             Error::NotFound => "Device not found.",
-//         };
-//     }
-// }


### PR DESCRIPTION
Fixes #1, and updates all examples to use the error propagation operator (`?`) instead of verbose `Result::unwrap` calls.